### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.replit

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@
 |   30	|   Bitwise AND	|   25-07-2020	|  [Link](/Day-29/) 	|    
   
   
- ### Python programme to generate Directory 
+[![Run on Repl.it](https://repl.it/badge/github/varunjha089/30-Days-of-Code)](https://repl.it/github/varunjha089/30-Days-of-Code)
+
+### Python programme to generate Directory 
  
 [***creating-directory.py***](/creating-directory.py) is used to automate this task.
    - It uses Python **OS** module.


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).